### PR TITLE
added livereload config from build config

### DIFF
--- a/src/tasks/config.dev.js
+++ b/src/tasks/config.dev.js
@@ -70,7 +70,7 @@ var devTasksConfig = {
      * plugin should auto-detect.
      */
     options: {
-      livereload: true,
+      livereload: config.build.server.withLiveReloadInDev,
       interval: 1007
     },
 


### PR DESCRIPTION
Made use of config.build.server.withLiveReloadInDev for watch task, since it is also used in connect task.
If they're not in sync, livereload will not work properly if you specify a port in withLiveReloadInDev.