### PR TITLE
Fix Livereload hostname

### DIFF
--- a/src/tasks/config.dev.js
+++ b/src/tasks/config.dev.js
@@ -24,7 +24,7 @@ var devTasksConfig = {
     dev: {
       options: {
         port: config.build.server.port,
-        hostname: '0.0.0.0',
+        hostname: '*',
         livereload: config.build.server.withLiveReloadInDev,
         base: config.build.prepare.outdir,
         middleware: utils.connectMiddleware


### PR DESCRIPTION
This seems to be an issue with the current grunt-contrib-connect lib. Changing the hostname from 0.0.0.0 to \* will start the livereload Server. (Issue found and fixed on Windows)
